### PR TITLE
Added op_size method

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1022,6 +1022,10 @@ impl StackTracker {
         (x, self.op(OP_2OVER, 0, true, &namey).unwrap())
     }
 
+    pub fn op_size(&mut self) -> StackVariable {
+        self.op(OP_SIZE, 0, true, "OP_SIZE()").unwrap()
+    }
+
     pub fn op_verify(&mut self) {
         let _ = self.op(OP_VERIFY, 1, false, "OP_VERIFY()");
     }


### PR DESCRIPTION
## Changes 

Add a new opcode op_size

## This change is related to other PRs in different libraries :

[Key manager](https://github.com/FairgateLabs/rust-bitvmx-key-manager/pull/58)

[Functions](https://github.com/FairgateLabs/rust-bitcoin-script-functions/pull/3) 

[Protocol Builder](https://github.com/FairgateLabs/rust-bitvmx-protocol-builder/pull/59)